### PR TITLE
Change serverThread to be a background thread

### DIFF
--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -97,6 +97,7 @@ namespace CRA.ClientLibrary
             // Then start server. This ensures that others can establish 
             // connections to local vertices at this point.
             Thread serverThread = new Thread(StartServer);
+            serverThread.IsBackground = true;
             serverThread.Start();
 
             // Wait for server to complete execution


### PR DESCRIPTION
This pull request sets the IsBackground property of the server thread to be true, making the server thread a background thread. According to the [.NET documentation](https://docs.microsoft.com/en-us/dotnet/api/system.threading.thread.isbackground?view=netframework-4.7), the only difference between a background thread and a foreground thread is that a running background thread does not prevent a process from terminating.

Making this change will allow apps that run a CRAWorker in a background thread, rather than a separate process, to exit cleanly. I am developing a Windows Forms app that runs a CRAWorker in a background thread, and before making this change, when I closed the app, the CRAWorker server thread kept the process running until I manually killed the process through the Task Manager. Now, when I close the app, the entire process terminates cleanly.

This change should not affect the behavior of existing apps that run the CRAWorker in a standalone process, since CRAWorker.Start() explicitly waits for the server thread to terminate using Join(). I tested the change with the standalone CRA.Worker.exe process, and it worked as expected. I'm not super-familiar with CRA, though, so it's worth doing more testing to make sure the change doesn't break anything.