### PR TITLE
Add methods for sideloading vertices and disabling dynamic assembly loading

### DIFF
--- a/src/CRA.ClientLibrary/CRA.ClientLibrary.csproj
+++ b/src/CRA.ClientLibrary/CRA.ClientLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard2.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>CRA.ClientLibrary</RootNamespace>

--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -842,14 +842,7 @@ namespace CRA.ClientLibrary
 
         public void SideloadVertex(IVertex vertex, string vertexName)
         {
-            var rows = VertexTable.GetAllRowsForInstance(_workerInstanceTable, _workerinstanceName);
-            var matchingRows = rows.Where((row) => vertexName == row.VertexName);
-            if (matchingRows.Count() != 1)
-            {
-                throw new Exception(string.Format("Incorrect number of rows with VertexName {0} (expected 1, got {1})", vertexName, matchingRows.Count()));
-            }
-            var vertexRow = matchingRows.ElementAt(0);
-            _craClient.SideloadVertexAsync(vertexRow.VertexName, vertexRow.VertexDefinition, _workerinstanceName, _localVertexTable, vertex).Wait();
+            _craClient.SideloadVertex(vertex, vertexName);
         }
 
         private void RestoreVerticesAndConnections()

--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -840,6 +840,18 @@ namespace CRA.ClientLibrary
             }
         }
 
+        public void SideloadVertex(IVertex vertex, string vertexName)
+        {
+            var rows = VertexTable.GetAllRowsForInstance(_workerInstanceTable, _workerinstanceName);
+            var matchingRows = rows.Where((row) => vertexName == row.VertexName);
+            if (matchingRows.Count() != 1)
+            {
+                throw new Exception("Incorrect number of matching rows");
+            }
+            var vertexRow = matchingRows.ElementAt(0);
+            _craClient.SideloadVertexAsync(vertexRow.VertexName, vertexRow.VertexDefinition, vertexRow.VertexParameter, _workerinstanceName, _localVertexTable, vertex).Wait();
+        }
+
         private void RestoreVerticesAndConnections()
         {
             var rows = VertexTable.GetAllRowsForInstance(_workerInstanceTable, _workerinstanceName);

--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -845,6 +845,11 @@ namespace CRA.ClientLibrary
             _craClient.SideloadVertex(vertex, vertexName);
         }
 
+        public void DisableDynamicLoading()
+        {
+            _craClient.DisableDynamicLoading();
+        }
+
         private void RestoreVerticesAndConnections()
         {
             var rows = VertexTable.GetAllRowsForInstance(_workerInstanceTable, _workerinstanceName);

--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -846,10 +846,10 @@ namespace CRA.ClientLibrary
             var matchingRows = rows.Where((row) => vertexName == row.VertexName);
             if (matchingRows.Count() != 1)
             {
-                throw new Exception("Incorrect number of matching rows");
+                throw new Exception(string.Format("Incorrect number of rows with VertexName {0} (expected 1, got {1})", vertexName, matchingRows.Count()));
             }
             var vertexRow = matchingRows.ElementAt(0);
-            _craClient.SideloadVertexAsync(vertexRow.VertexName, vertexRow.VertexDefinition, vertexRow.VertexParameter, _workerinstanceName, _localVertexTable, vertex).Wait();
+            _craClient.SideloadVertexAsync(vertexRow.VertexName, vertexRow.VertexDefinition, _workerinstanceName, _localVertexTable, vertex).Wait();
         }
 
         private void RestoreVerticesAndConnections()


### PR DESCRIPTION
This pull request adds support for disabling dynamic assembly loading and for "sideloading" vertices by initializing a Vertex object and passing it into the CRA Worker directly. These changes are motivated by the constraints of two different programming environments:

Universal Windows Platform: UWP apps cannot load assemblies dynamically at runtime. The sideloading interface provides an alternate means of initializing vertices.

.NET Core on Linux: Unlike UWP, .NET Core on Linux allows dynamically loading assemblies, but problems arise when one CRA Worker overwrites the assemblies that an already-running CRA Worker has dynamically loaded. The ability to explicitly disable dynamic assembly loading was added to support .NET Core on Linux.

Each of the two added features (sideloading vertices and disabling dynamic assembly loading) is designed so that it does not interfere with the normal-case usage of CRA. To access these features, developers simply call additional methods before running CRAWorker.Start().

This PR also adds a .NET Standard 2.0 target to CRA.ClientLibrary, since a .NET Standard build is required for UWP development, and CRA is completely .NET Standard-compliant anyways.