### PR TITLE
Disable artifact uploading.

### DIFF
--- a/src/CRA.ClientLibrary/Main/ShardedCRAClientLibrary.cs
+++ b/src/CRA.ClientLibrary/Main/ShardedCRAClientLibrary.cs
@@ -21,13 +21,16 @@ namespace CRA.ClientLibrary
         /// <param name="creator">Lambda that describes how to instantiate the vertex, taking in an object as parameter</param>
         public CRAErrorCode DefineVertex(string vertexDefinition, Expression<Func<IShardedVertex>> creator)
         {
-            CloudBlobContainer container = _blobClient.GetContainerReference("cra");
-            container.CreateIfNotExistsAsync().Wait();
-            var blockBlob = container.GetBlockBlobReference(vertexDefinition + "/binaries");
-            CloudBlobStream blobStream = blockBlob.OpenWriteAsync().GetAwaiter().GetResult();
-            AssemblyUtils.WriteAssembliesToStream(blobStream);
-            blobStream.Close();
-
+            if (_artifactUploading)
+            {
+                CloudBlobContainer container = _blobClient.GetContainerReference("cra");
+                container.CreateIfNotExistsAsync().Wait();
+                var blockBlob = container.GetBlockBlobReference(vertexDefinition + "/binaries");
+                CloudBlobStream blobStream = blockBlob.OpenWriteAsync().GetAwaiter().GetResult();
+                AssemblyUtils.WriteAssembliesToStream(blobStream);
+                blobStream.Close();
+            }
+            
             // Add metadata
             var newRow = new VertexTable("", vertexDefinition, vertexDefinition, "", 0, creator, null, true);
             TableOperation insertOperation = TableOperation.InsertOrReplace(newRow);


### PR DESCRIPTION
CRA provides an option for not dynamically loading assemblies at runtime.  However, the user of CRA still needs to upload these artifacts when registering the vertex.  Provide an option to prevent uploading that can be combined with dynamic downloading and sideloading.