### PR TITLE
Fix thread scheduling in CRA Worker

### DIFF
--- a/src/CRA.ClientLibrary/Main/CRAWorker.cs
+++ b/src/CRA.ClientLibrary/Main/CRAWorker.cs
@@ -883,7 +883,7 @@ namespace CRA.ClientLibrary
             }
         }
 
-        private void RetryRestoreConnection(string fromVertexName, string fromVertexOutput, string toVertexName, string toVertexInput, bool reverse)
+        private async Task RetryRestoreConnection(string fromVertexName, string fromVertexOutput, string toVertexName, string toVertexInput, bool reverse)
         {
             var conn = reverse ? inConnections : outConnections;
 
@@ -902,7 +902,7 @@ namespace CRA.ClientLibrary
                 {
                     if (result == CRAErrorCode.ServerRecovering)
                         killRemote = true;
-                    Thread.Sleep(5000);
+                    await Task.Delay(5000);
                 }
                 else
                     break;

--- a/src/Samples/ConnectionPair/MyAsyncOutput.cs
+++ b/src/Samples/ConnectionPair/MyAsyncOutput.cs
@@ -46,7 +46,7 @@ namespace ConnectionPair
 
                 for (int j = 0; j < 1; j++)
                 {
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000);
                     token.ThrowIfCancellationRequested();
                 }
 

--- a/src/Samples/FusableConnectionPair/MyAsyncFusableOutput.cs
+++ b/src/Samples/FusableConnectionPair/MyAsyncFusableOutput.cs
@@ -46,7 +46,7 @@ namespace FusableConnectionPair
 
                 for (int j = 0; j < 1; j++)
                 {
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000);
                     token.ThrowIfCancellationRequested();
                 }
 
@@ -77,7 +77,7 @@ namespace FusableConnectionPair
 
                 for (int j = 0; j < 1; j++)
                 {
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000);
                     token.ThrowIfCancellationRequested();
                 }
 

--- a/src/Samples/ShardedConnectionPair/MyAsyncOutput.cs
+++ b/src/Samples/ShardedConnectionPair/MyAsyncOutput.cs
@@ -46,7 +46,7 @@ namespace ShardedConnectionPair
 
                 for (int j = 0; j < 1; j++)
                 {
-                    Thread.Sleep(1000);
+                    await Task.Delay(1000);
                     token.ThrowIfCancellationRequested();
                 }
 


### PR DESCRIPTION
Task.Run() schedules tasks onto a fixed set of thread pool threads. If one of those tasks then calls Thread.Sleep(), it will hog the thread and prevent any other tasks from being scheduled onto that thread while it sleeps. As a result, performance suffers, and deadlocks result in some circumstances.

Jonathan and I discussed this change and confirmed that it fixed a deadlock bug that we were seeing in PerformanceTestInterruptible.