### PR TITLE
Hotfix for a bug in assembly upload

### DIFF
--- a/src/CRA.ClientLibrary/Utilities/AssemblyUtils.cs
+++ b/src/CRA.ClientLibrary/Utilities/AssemblyUtils.cs
@@ -707,6 +707,13 @@ namespace CRA.ClientLibrary
                 AssemblyName assemblyFullName = new AssemblyName(assemblyName);
                 var assemblyPath = Path.Combine(AssemblyDirectory, assemblyFullName.Name + ".dll");
 
+                if (assemblyName.Equals(assemblyFullName.Name))
+                {   //this means the public key info etc is missing
+                    //this assembly is probably an uploaded project reference
+                    //just skip over it, the actual assembly will show up on the stream
+                    continue;
+                }
+
                 if (assemblyLock.TryAdd(assemblyPath, true))
                 {
                     try


### PR DESCRIPTION
When developing a project which depends on Microsoft.CRA and has local project references the following seems to happen:

- during assembly upload to azure, the project references AND their binaries get uploaded (so they are twice in there)
- importantly, if the project reference is in the blob **before** the actual assembly, then during download it will block the actual assembly from being loaded (its added to _assemblyLock)
- now when the runtime needs this assembly, it will not find the real assembly, only the project reference which has no info like public key etc. resulting in a filenotfoundexception and failing startup of the CRA instance.

This hotfix will not fix the underlying issue (the incorrect uploading of project references) but will skip over these entries in the binaries blob while downloading. Therefore preventing the aforementioned exception.